### PR TITLE
Fix nav indentation and enable body parsing

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -10,6 +10,8 @@ const logger = morgan("dev");
 app.set("view engine", "pug");
 app.set("views", process.cwd() + "/src/views");
 app.use(logger);
+app.use(express.urlencoded({ extended: true }));
+app.use(express.json());
 
 app.use("/", rootRouter);
 

--- a/src/views/base.pug
+++ b/src/views/base.pug
@@ -6,13 +6,13 @@ html(lang="ko")
     block style
   body
     header
-        h1=pageTitle
-        nav
-            ul
-                li
-                a(href="/") Home
-                li
-                a(href="/draw") Draw
-    main 
+      h1=pageTitle
+      nav
+        ul
+          li
+            a(href="/") Home
+          li
+            a(href="/draw") Draw
+    main
         block content
         block script


### PR DESCRIPTION
## Summary
- fix indentation for navigation links
- enable body parsing for draw canvas API

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683fe28b5a188333bc2da330a17d3266